### PR TITLE
Ignore SASS (.sass/.scss) and CSS (.css) files

### DIFF
--- a/generate_sitemap.rb
+++ b/generate_sitemap.rb
@@ -84,10 +84,10 @@ module Jekyll
         path     = page.subfolder + '/' + page.name
         mod_date = File.mtime(site.source + path)
 
-		# Ignore SASS, SCSS, and CSS files
-		if path=~/.(sass|scss|css)$/
-			next
-		end
+        # Ignore SASS, SCSS, and CSS files
+        if path=~/.(sass|scss|css)$/
+          next
+        end
 
         # Remove the trailing 'index.html' if there is one, and just output the folder name.
         if path=~/index.html$/

--- a/generate_sitemap.rb
+++ b/generate_sitemap.rb
@@ -84,6 +84,11 @@ module Jekyll
         path     = page.subfolder + '/' + page.name
         mod_date = File.mtime(site.source + path)
 
+		# Ignore SASS, SCSS, and CSS files
+		if path=~/.(sass|scss|css)$/
+			next
+		end
+
         # Remove the trailing 'index.html' if there is one, and just output the folder name.
         if path=~/index.html$/
             path = path[0..-11]


### PR DESCRIPTION
The sitemap currently includes CSS (*.css) files, as well as [SASS](http://sass-lang.com/) (*.sass or *.scss) files (which end up being converted into .css files). This patch skips those files in the sitemap. (I don’t actually “know” Ruby, but this seems to work okay! Thanks for the cool plugin!)
