### PR TITLE
Allow 'changefreq' to be specified for each page

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -126,6 +126,11 @@ How it works
 
 When you compile your Jekyll site, the plugin will loop through the list of pages in your site, and generate an entry in _sitemap.xml_ for each one.
 
+Available YAML settings
+-----------------------
+
+* _changefreq_ : How often this page will change. This setting is optional, but if specified its value must be one of `always`, `hourly`, `daily`, `weekly`, `monthly`, `yearly`, or `never`. See [the sitemap specification](http://www.sitemaps.org/protocol.php#xmlTagDefinitions) for more details on what this is used for. By default, this property is omitted for static pages and `never` for the files in `_posts` (since these are typically blog entries or the like).
+
 
 Change history
 ==============

--- a/generate_sitemap.rb
+++ b/generate_sitemap.rb
@@ -91,16 +91,27 @@ module Jekyll
 
         # rename any md files to html (as that is how they appear in _site)
         path.gsub!( /.md$/, ".html" )
+
+        if page.data.has_key?('changefreq')
+          changefreq = page.data["changefreq"]
+        else
+          changefreq = ""
+        end
         
         unless path =~/error/
-          result += entry(path, mod_date, site)
+          result += entry(path, mod_date, changefreq, site)
         end
       }
       
       # Next, find all the posts.
       posts = site.site_payload['site']['posts']
       for post in posts do
-        result += entry("/"+post.url, post.date, site)
+        if post.data.has_key?('changefreq')
+          changefreq = post.data["changefreq"]
+        else
+          changefreq = "never"
+        end
+        result += entry("/"+post.url, post.date, changefreq, site)
       end
       
         result
@@ -115,11 +126,15 @@ module Jekyll
     #
     #  +path+ is the URL path to the page.
     #  +date+ is the date the file was modified (in the case of regular pages), or published (for blog posts).
-    def entry(path, date, site)
+    #  +changefreq+ is the frequency with which the page is expected to change (this information is used by
+    #    e.g. the Googlebot). This may be specified in the page's YAML front matter. If it is not set, nothing
+    #    is output for this property.
+    def entry(path, date, changefreq, site)
       "
   <url>
       <loc>#{site.config['baseurl']}#{path}</loc>
-      <lastmod>#{date.strftime("%Y-%m-%d")}</lastmod>
+      <lastmod>#{date.strftime("%Y-%m-%d")}</lastmod>#{if changefreq.length > 0
+          "\n      <changefreq>#{changefreq}</changefreq>" end}
   </url>"
     end
 


### PR DESCRIPTION
The sitemap.xml format contains an optional element "changefreq" which, if given, tells the search-engine robots approximately how often a given page will change. For example, the front page of a site might change daily, but archived blog posts probably never change. This branch checks to see whether a "changefreq" has been specified in a file's YAML front matter and, if so, this is added to the sitemap.xml. (If no changefreq is specified then the element is omitted from the XML.)
