### PR TITLE
Add missing slashes to post URLs in sitemap

### DIFF
--- a/generate_sitemap.rb
+++ b/generate_sitemap.rb
@@ -99,7 +99,7 @@ module Jekyll
 
         # Remove the trailing 'index.html' if there is one, and just output the folder name.
         if path=~/\/index.html$/
-            path = path[0..-11]
+          path = path[0..-11]
         end
 
         if page.data.has_key?('changefreq')
@@ -121,7 +121,7 @@ module Jekyll
         else
           changefreq = "never"
         end
-        url = post.url
+        url = "/" + post.url
         url = url[0..-11] if url=~/\/index.html$/
         result += entry(url, post.date, changefreq, site)
       end


### PR DESCRIPTION
The URLs in the sitemap were fine for the site's static pages, but the post (e.g. blog) URLs were missing slashes:

```
http://www.example.comblog/2011/foobar
```

instead of

```
http://www.example.com/blog/2011/foobar
```
