### PR TITLE
Rewrite of the category_links filter using liquid

### DIFF
--- a/layouts/category_index.html
+++ b/layouts/category_index.html
@@ -7,6 +7,20 @@ layout: default
 {% for post in site.categories[page.category] %}
     <div>{{ post.date | date_to_html_string }}</div>
     <h2><a href="{{ post.url }}">{{ post.title }}</a></h2>
-    <div class="categories">Filed under {{ post.categories | category_links }}</div>
+    <div class="categories">Filed under     
+        
+        {% for item in post.categories %} 
+    				
+    		{% if forloop.last %}
+    			and 
+    		{% endif %}
+    		
+    		<a href="/{{ site.category_dir }}/{{ item }}">{{ item }}</a>
+    		
+    		{% unless forloop.last or forloop.rindex == 2%},{% endunless %}
+    		
+    	{% endfor %}
+        
+    </div>
 {% endfor %}
 </ul>


### PR DESCRIPTION
The category_links filter needs to have the category url hard coded in the method, and cannot not use the category_dir option defined in _config.yml.

This is basically a rewrite of the category_links filter using liquid, that uses the category_dir option from _config.yml to generate the anchor markup.
This also makes possible customizing the markup for the category links.

Using this makes the category_links filter obsolete.
