### PR TITLE
Check that a static page exists before acting on it

### DIFF
--- a/generate_sitemap.rb
+++ b/generate_sitemap.rb
@@ -82,6 +82,9 @@ module Jekyll
       # First, try to find any stand-alone pages.      
       site.pages.each{ |page|
         path     = page.subfolder + '/' + page.name
+        if not File.exists? site.source + path then
+          next
+        end
         mod_date = File.mtime(site.source + path)
 
         # Use the user-specified permalink if one is given.


### PR DESCRIPTION
Pages created by generators otherwise cause an error. e.g. pagination.

Example of said error:

```
[03:57][david@plug:~/src/jekyll_test(master)]$ jekyll
Configuration from /home/david/src/jekyll_test/_config.yml
Building site: /home/david/src/jekyll_test -> /home/david/src/jekyll_test/_site
/home/david/src/jekyll_test/_plugins/generate_sitemap.rb:85:in `mtime': No such file or directory - /home/david/src/jekyll_test/blog/page/2/index.html (Errno::ENOENT)
    from /home/david/src/jekyll_test/_plugins/generate_sitemap.rb:85:in `block in generate_content'
    from /home/david/src/jekyll_test/_plugins/generate_sitemap.rb:83:in `each'
    from /home/david/src/jekyll_test/_plugins/generate_sitemap.rb:83:in `generate_content'
    from /home/david/src/jekyll_test/_plugins/generate_sitemap.rb:60:in `block in generate'
    from /home/david/src/jekyll_test/_plugins/generate_sitemap.rb:58:in `open'
    from /home/david/src/jekyll_test/_plugins/generate_sitemap.rb:58:in `generate'
    from /usr/lib/ruby/gems/1.9.1/gems/jekyll-0.11.0/lib/jekyll/site.rb:184:in `block in generate'
    from /usr/lib/ruby/gems/1.9.1/gems/jekyll-0.11.0/lib/jekyll/site.rb:183:in `each'
    from /usr/lib/ruby/gems/1.9.1/gems/jekyll-0.11.0/lib/jekyll/site.rb:183:in `generate'
    from /usr/lib/ruby/gems/1.9.1/gems/jekyll-0.11.0/lib/jekyll/site.rb:39:in `process'
    from /usr/lib/ruby/gems/1.9.1/gems/jekyll-0.11.0/bin/jekyll:250:in `<top (required)>'
    from /usr/bin/jekyll:19:in `load'
    from /usr/bin/jekyll:19:in `<main>'
```
