### PR TITLE
Include the site domain if "url" is set on config.

### DIFF
--- a/generate_sitemap.rb
+++ b/generate_sitemap.rb
@@ -140,10 +140,11 @@ module Jekyll
       # Remove the trailing slash from the baseurl if it is present, for consistency.
       baseurl = site.config['baseurl']
       baseurl = baseurl[0..-2] if baseurl=~/\/$/
+      url     = site.config['url']
 
       "
   <url>
-    <loc>#{baseurl}#{path}</loc>
+    <loc>#{url}#{baseurl}#{path}</loc>
     <lastmod>#{date.strftime("%Y-%m-%d")}</lastmod>
 " + attrs.map { |k,v| "    <#{k}>#{v}</#{k}>" }.join("\n") + "
   </url>"


### PR DESCRIPTION
The `<loc>` tag [should include the site domain](http://www.sitemaps.org/protocol.html#xmlTagDefinitions)

If the `url` config option is set it is used as the domain. Otherwise don't include any domain.

The sitemap.xml doesn't validate on google webmaster tools if the `<loc>` don't include the domain.
