### PR TITLE
Verify if page exists inside "destination"

### DIFF
--- a/generate_sitemap.rb
+++ b/generate_sitemap.rb
@@ -82,9 +82,10 @@ module Jekyll
       # First, try to find any stand-alone pages.
       site.pages.each { |page|
         path = page.subfolder + '/' + page.name
+        filepath = File.join(site.config['destination'], page.subfolder, page.name)
 
         # Skip files that don't exist yet (e.g. paginator pages)
-        next unless FileTest.exist?(path)
+        next unless FileTest.exist?(filepath)
 
         mod_date = File.mtime(site.source + path)
 


### PR DESCRIPTION
The site config `destination` is the directory where Jekyll will create the files, so when verifying if a page exists to include on the sitemap search inside this directory.
