### PR TITLE
Update category_dir to closer match of wordpress

### DIFF
--- a/generate_categories.rb
+++ b/generate_categories.rb
@@ -188,7 +188,7 @@ module Jekyll
     # back on the default if no dir is provided.
     def self.category_dir(base_dir, category)
       base_dir = (base_dir || CATEGORY_DIR).gsub(/^\/*(.*)\/*$/, '\1')
-      category = category.gsub(/_|\P{Word}/, '-').gsub(/-{2,}/, '-').downcase
+      category = category.gsub(/\./, '').gsub(/_|\P{Word}/, '-').gsub(/-{2,}/, '-').downcase
       File.join(base_dir, category)
     end
 


### PR DESCRIPTION
When Wordpress creates a slug, periods are just stripped from the result, e.g. "Web 2.0" becomes "web-20".
