### PR TITLE
Added subdirectory support inside the categories pages.

### DIFF
--- a/_layouts/category_index.html
+++ b/_layouts/category_index.html
@@ -6,7 +6,7 @@ layout: default
 <ul class="posts">
 {% for post in site.categories[page.category] %}
     <div>{{ post.date | date_to_html_string }}</div>
-    <h2><a href="{{ post.url }}">{{ post.title }}</a></h2>
+    <h2><a href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a></h2>
     <div class="categories">Filed under {{ post.categories | category_links }}</div>
 {% endfor %}
 </ul>

--- a/generate_categories.rb
+++ b/generate_categories.rb
@@ -205,12 +205,19 @@ module Jekyll
     #
     # Returns string
     def category_links(categories)
+      site_base_url = @context.registers[:site].config['baseurl']
       base_dir = @context.registers[:site].config['category_dir']
       categories = categories.sort!.map do |category|
         category_dir = GenerateCategories.category_dir(base_dir, category)
-        # Make sure the category directory begins with a slash.
-        category_dir = "/#{category_dir}" unless category_dir =~ /^\//
-        "<a class='category' href='#{category_dir}/'>#{category}</a>"
+        # Remove the leading slash if there is one
+        category_dir = category_dir.gsub(/^\//, '')
+        # Use the site's baseurl if it is set, otherwise we 404
+        if not site_base_url.nil? and not site_base_url.empty?
+          base_url = site_base_url
+        else
+          base_url = "/"
+        end
+        "<a class='category' href='#{base_url}#{category_dir}/'>#{category}</a>"
       end
 
       case categories.length


### PR DESCRIPTION
When using `generate_categories.rb` on a site which has been placed into a subdirectory via the `baseurl` config variable, links from the category pages result in a 404, as they are not given the full URL.
